### PR TITLE
Fix arrows to be vertical regardless of icon

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -283,13 +283,17 @@ body {
 .work-entry summary {
     position: relative;
     padding-left: 2em;
+    display: flex;
+    align-items: center;
+    min-height: 2.2em;
 }
 
 .work-entry summary::before {
     content: '\25B6';
     position: absolute;
     left: 0.2em;
-    top: 0.7em;
+    top: 50%;
+    transform: translateY(-50%);
     font-size: 1.1em;
     color: #ffd700;
     transition: transform 0.2s;


### PR DESCRIPTION
### Description
Doing more mobile testing, I noted that the arrows were not aligned for certain sections. Deeper investigation, I noted it was because the fa fa icons were not taken into consideration like the company logos were.

Updated `styles.css` to handle vertical regardless.